### PR TITLE
Redirection acces4all vers acceslibre.beta.gouv.fr

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -40,3 +40,9 @@ server {
   listen <%= ENV['PORT'] %>;
   rewrite ^/(.*)$ https://code.travail.gouv.fr/;
 }
+
+server {
+  server_name acces4all.beta.gouv.fr;
+  listen <%= ENV['PORT'] %>;
+  rewrite ^/(.*)$ https://acceslibre.beta.gouv.fr/$1 permanent;
+}


### PR DESCRIPTION
Redirige `acces4all.beta.gouv.fr` vers `acceslibre.beta.gouv.fr` de façon permanante.