### PR TITLE
Tentative de rétablissement wikicarbone.beta.gouv.fr

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -165,6 +165,27 @@ server {
 }
 
 server {
+  server_name wikicarbone.beta.gouv.fr;
+  listen <%= ENV['PORT'] %>;
+  location / {
+      proxy_pass https://wikicarbone.osc-fr1.scalingo.io/;
+
+      if ($request_uri ~* "/(.*)") {
+          proxy_pass  https://wikicarbone.osc-fr1.scalingo.io/$1;
+      }
+
+      proxy_intercept_errors  on;
+
+      proxy_redirect          default;
+      proxy_buffering         off;
+      proxy_set_header        Host                 wikicarbone.osc-fr1.scalingo.io;
+      proxy_set_header        X-Real-IP            $remote_addr;
+      proxy_set_header        X-Forwarded-For      $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Protocol $scheme;
+  }
+}
+
+server {
   server_name dashlord.mte.incubateur.net;
   listen <%= ENV['PORT'] %>;
   location / {


### PR DESCRIPTION
Contexte : https://github.com/MTES-MCT/wikicarbone/pull/52 /cc @tristanrobert 

Le commit 9b80e3af77734b4b17de7bafe5e198f0182546f8 a supprimé toute gestion du domaine `wikicarbone.beta.gouv.fr`, alors qu'il faut juste le faire pointer vers Scalingo (`wikicarbone.osc-fr1.scalingo.io`). Idéalement un simple enregistrement DNS devrait suffire, mais je n'ai pas la main dessus, d'où cette PR "à l'arrache" car le site Wikicarbone est actuellement down.
