### PR TITLE
Redirection peps.beta.gouv.fr -> rex-agri.agroecologie.org

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -266,3 +266,8 @@ server {
   return 301 $scheme://openacademie.fr$request_uri;
 }
 
+server {
+  server_name peps.beta.gouv.fr;
+  listen <%= ENV['PORT'] %>;
+  return 301 $scheme://rex-agri.agroecologie.org$request_uri;
+}


### PR DESCRIPTION
Redirection peps.beta.gouv.fr -> rex-agri.agroecologie.org