### PR TITLE
Force wikicarbone/ecobalyse redirections to use HTTPS.

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -227,5 +227,5 @@ server {
 server {
   server_name wikicarbone.beta.gouv.fr;
   listen <%= ENV['PORT'] %>;
-  return 301 $scheme://ecobalyse.beta.gouv.fr$request_uri;
+  return 301 https://ecobalyse.beta.gouv.fr$request_uri;
 }


### PR DESCRIPTION
So that previous API clients don't get security errors when requesting the previous hostname.

![2022-05-24 at 13 35](https://user-images.githubusercontent.com/41547/170025645-fa576a7f-1916-4845-99c8-e22b10bf630b.png)
