### PR TITLE
Correction du domaine impact

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -225,7 +225,7 @@ server {
 }
   
 server {
-  server_name impact.beta.gouv.fr wwww.impact.beta.gouv.fr;
+  server_name impact.beta.gouv.fr www.impact.beta.gouv.fr;
   listen <%= ENV['PORT'] %>;
   return 301 https://portail-rse.beta.gouv.fr$request_uri;
 }


### PR DESCRIPTION
Je n'avais pas vu qu'il y avait un caractère 'w' en trop dans le second domaine. Cette PR le supprime.

@jdauphant je n'ai pas les droits pour fusionner la PR moi-même (et il semble inutile de me les donner puisque je ne vais probablement jamais remodifier ce dépôt).