### PR TITLE
Ajoute comparia.beta.gouv.fr

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -241,3 +241,9 @@ server {
   listen <%= ENV['PORT'] %>;
   return 301 https://stop-punaises.gouv.fr$request_uri;
 }
+
+server {
+  server_name comparia.beta.gouv.fr;
+  listen <%= ENV['PORT'] %>;
+  return 302 https://www.comparia.beta.gouv.fr$request_uri;
+}


### PR DESCRIPTION
Redirection temporaire le temps de s'assurer que le setup DNS est bien celui voulu.