### PR TITLE
Redirect public site Mon Suivi Justice to Justice.fr

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -223,7 +223,7 @@ server {
   listen <%= ENV['PORT'] %>;
   return 301 https://www.eig.numerique.gouv.fr$request_uri;
 }
-  
+
 server {
   server_name impact.beta.gouv.fr www.impact.beta.gouv.fr;
   listen <%= ENV['PORT'] %>;
@@ -240,4 +240,10 @@ server {
   server_name stop-punaises.beta.gouv.fr;
   listen <%= ENV['PORT'] %>;
   return 301 https://stop-punaises.gouv.fr$request_uri;
+}
+
+server {
+  server_name mon-suivi-justice.beta.gouv.fr;
+  listen <%= ENV['PORT'] %>;
+  return 301 https://www.justice.fr/mon-suivi-justice;
 }


### PR DESCRIPTION
Comme discuté avec @LucasCharrier , nous souhaitons rediriger le traffic de notre site public Mon Suivi Justice vers une page dédiée sur Justice.fr dans le cadre de notre pérennisation 