### PR TITLE
Redirect convict interface to main app

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -249,6 +249,12 @@ server {
 }
 
 server {
+  server_name probationnaire.mon-suivi-justice.beta.gouv.fr;
+  listen <%= ENV['PORT'] %>;
+  return 301 https://www.mon-suivi-justice.beta.gouv.fr/convict_interface;
+}
+
+server {
   server_name comparia.beta.gouv.fr;
   listen <%= ENV['PORT'] %>;
   return 301 https://www.comparia.beta.gouv.fr$request_uri;

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -251,7 +251,7 @@ server {
 server {
   server_name probationnaire.mon-suivi-justice.beta.gouv.fr;
   listen <%= ENV['PORT'] %>;
-  return 301 https://www.mon-suivi-justice.beta.gouv.fr/convict_interface;
+  return 301 https://agents.mon-suivi-justice.beta.gouv.fr/convict_interface;
 }
 
 server {


### PR DESCRIPTION
Important : J'ouvre cette PR en avance. Ne pas la merger avant le 31 mars !!!

Le 31 mars, nous décommissionnerons l'application accessible sur probationnaire.mon-suivi-justice.beta.gouv.fr. Nous aimerions que toute personne se rendant sur ce domaine soit redirigée vers https://www.mon-suivi-justice.beta.gouv.fr/convict_interface. Est ce bien ce que ferait cette PR ? Quelles sont les autres actions à effectuer ?